### PR TITLE
Small layouting changes

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -144,7 +144,7 @@ App::MessageReceived(BMessage *msg)
 				ew_message = fDataMessage;
 			}
 			
-			EditWindow *edit_window = new EditWindow(BRect(0,0,220,200), 
+			EditWindow *edit_window = new EditWindow(BRect(0,0,0,0), 
 													ew_message,
 													fSelectedType,
 													fSelectedName,

--- a/src/datawindow.cpp
+++ b/src/datawindow.cpp
@@ -25,7 +25,7 @@ DataWindow::DataWindow(BRect frame,
 					type_code field_type,
 					int32 item_count)
 	:
-	BWindow(frame, B_TRANSLATE("Message Data"), B_TITLED_WINDOW, B_CLOSE_ON_ESCAPE),
+	BWindow(frame, B_TRANSLATE("Message data"), B_TITLED_WINDOW, B_CLOSE_ON_ESCAPE),
 	fDataMessage(data_message),
 	fFieldName(field_name),
 	fFieldType(field_type),
@@ -53,12 +53,9 @@ DataWindow::DataWindow(BRect frame,
 	
 	fCloseButton = new BButton(B_TRANSLATE("Close"), new BMessage(DW_BUTTON_CLOSE));
 
-	BLayoutBuilder::Group<>(this, B_VERTICAL,0)
-		.SetInsets(5)
-		.AddGroup(B_HORIZONTAL)
-			.SetInsets(5)
-			.Add(fDataLabel)
-		.End()	
+	BLayoutBuilder::Group<>(this, B_VERTICAL, B_USE_SMALL_SPACING)
+		.SetInsets(B_USE_SMALL_SPACING)
+		.Add(fDataLabel)
 		.Add(fDataView)
 		.Add(fCloseButton)
 	.Layout();

--- a/src/editwindow.cpp
+++ b/src/editwindow.cpp
@@ -21,20 +21,25 @@ EditWindow::EditWindow(BRect frame,
 					const char *data_label,
 					int32 data_index)
 	:
-	BWindow(frame, B_TRANSLATE("Edit"), B_TITLED_WINDOW,B_CLOSE_ON_ESCAPE)
+	BWindow(frame, B_TRANSLATE("Edit"), B_TITLED_WINDOW, B_CLOSE_ON_ESCAPE
+		| B_NOT_ZOOMABLE | B_NOT_V_RESIZABLE | B_AUTO_UPDATE_SIZE_LIMITS)
 {
 
 	fEditView = new EditView(data_message, data_type, data_label, data_index);
 	fCancelButton = new BButton(B_TRANSLATE("Cancel"), new BMessage(EW_BUTTON_CANCEL));
 	fSaveButton = new BButton(B_TRANSLATE("Save"), new BMessage(EW_BUTTON_SAVE));
 	
-	BLayoutBuilder::Group<>(this, B_VERTICAL,0)
-		.SetInsets(5)
+	BLayoutBuilder::Group<>(this, B_VERTICAL, B_USE_SMALL_SPACING)
+		.SetInsets(B_USE_SMALL_SPACING)
 		.Add(fEditView)
+		.AddStrut(B_USE_BIG_SPACING)
 		.AddGroup(B_HORIZONTAL)
+			.AddGlue()
 			.Add(fCancelButton)
 			.Add(fSaveButton)
+			.AddGlue()
 		.End()
+		.AddGlue(100)
 	.Layout();
 	
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -51,7 +51,7 @@ MainWindow::MainWindow(float left, float top, float right, float bottom)
 		.SetInsets(0)
 		.Add(fTopMenuBar)
 		.AddGroup(B_HORIZONTAL)
-			.SetInsets(5,3,3,3)
+			.SetInsets(-1,-1,-1,-1)
 			.Add(fMessageInfoView,20)		
 	.Layout();
 
@@ -273,9 +273,9 @@ MainWindow::continue_action()
 {
 	BAlert *not_saved_alert = new BAlert(
 		"", 
-		B_TRANSLATE("The message data was changed but not saved. Do you really want to continue?"),
-		B_TRANSLATE("No"),
-		B_TRANSLATE("Yes"),
+		B_TRANSLATE("The message data was changed but not saved. Do you really want to quit?"),
+		B_TRANSLATE("Cancel"),
+		B_TRANSLATE("Quit"),
 		NULL,
 		B_WIDTH_AS_USUAL,
 		B_WARNING_ALERT);

--- a/src/messageview.cpp
+++ b/src/messageview.cpp
@@ -25,7 +25,7 @@ MessageView::MessageView()
 	BIntegerColumn *index_column = new BIntegerColumn(B_TRANSLATE("Index"),70,10,100);
 	BStringColumn *name_column = new BStringColumn(B_TRANSLATE("Name"),200,50,1000,0);
 	BStringColumn *type_column = new BStringColumn(B_TRANSLATE("Type"),200,50,1000,0);
-	BIntegerColumn *count_column = new BIntegerColumn(B_TRANSLATE("Number of Items"),120,10,150);
+	BIntegerColumn *count_column = new BIntegerColumn(B_TRANSLATE("Number of items"),120,10,150);
 
 	AddColumn(index_column,0);
 	AddColumn(name_column,1);


### PR DESCRIPTION
* Remove small insets around the list in main window.
* Simplified layout code in data window.
* Use system constants for insets.
* Center align buttons in edit window, add a bit of padding above
  buttons, make window non-resizable.
* Use sentence casing.
* Changed Yes/No alert buttons to Quit/Cancel. Always better to
  have the label be the actual actions.