### PR TITLE
Adding russian translation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ LIBPATHS =
 SYSTEM_INCLUDE_PATHS = /boot/system/develop/headers/private/interface
 LOCAL_INCLUDE_PATHS =
 OPTIMIZE := 
-LOCALES = en de nl
+LOCALES = en de nl ru
 DEFINES=
 WARNINGS = ALL
 SYMBOLS := 
@@ -55,4 +55,3 @@ APP_VERSION :=
 DEVEL_DIRECTORY := \
 	$(shell findpaths -r "makefile_engine" B_FIND_PATH_DEVELOP_DIRECTORY)
 include $(DEVEL_DIRECTORY)/etc/makefile-engine
-

--- a/locales/ru.catkeys
+++ b/locales/ru.catkeys
@@ -1,0 +1,37 @@
+1	English	application/x-vnd.BlueSky-Kottan	1453004971
+Name	MessageView		Имя
+Blue:	EditView		Синий:
+About	MainWindow		О программе
+Top:	EditView		Верх:
+Number of Items	MessageView		Количество элементов
+data cannot be displayed	DataWindow		невозможно показать данные
+Quit	MainWindow		Выход
+No	MainWindow		Нет
+Index	DataWindow		№ п/п
+Bottom:	EditView		Низ:
+Type	MessageView		Тип данных
+Yes	MainWindow		Да
+Red:	EditView		Красный:
+Error opening the message file!	App		Ошибка при открытии файла BMessage!
+Help	MainWindow		Помощь
+Green:	EditView		Зелёный:
+Index	MessageView		№ п/п
+The message data was changed but not saved. Do you really want to continue?	MainWindow		Данные в BMessage были изменены, но изменения не были сохранены. Вы уверены, что хотите продолжать?
+Left:	EditView		Левая граница:
+Width:	EditView		Ширина:
+Height:	EditView		Высота:
+Save	MainWindow		Сохранить
+File	MainWindow		Файл
+Open	MainWindow		Открыть
+Right:	EditView		Правая граница:
+Value	DataWindow		Значение
+Cancel	EditWindow		Отмена
+Edit	EditWindow		Редактировать
+Close	DataWindow		Закрыть
+Alpha:	EditView		Альфа-канал:
+Save	EditWindow		Сохранить
+Error reading the message from the file!	App		Ошибка при чтении BMessage из файла!
+Message Data	DataWindow		Данные BMessage
+An editor for archived BMessages	App		Редактор сохранённых файлов BMessage
+essage
+essage


### PR DESCRIPTION
Added ru.catkeys file. Verified, it works correctly.
I translated even attributes of BRect and BSize - probably that's not a good idea, because they're constant technical terms, (one can never refer to "BRect.Right" as "BRect.Rechts", and it doesn't matter what locale he has), but I thought they should be translated anyway, since in German locale they are translated.