### PR TITLE
Position of opening windows, localization

### DIFF
--- a/locales/de.catkeys
+++ b/locales/de.catkeys
@@ -1,4 +1,4 @@
-1	English	application/x-vnd.BlueSky-Kottan	2464514700
+1	German	application/x-vnd.BlueSky-Kottan	2960400911
 Name	MessageView		Name
 Blue:	EditView		Blau:
 About	MainWindow		Über
@@ -7,22 +7,24 @@ data cannot be displayed	DataWindow		Daten können nicht angezeigt werden
 Quit	MainWindow		Beenden
 Index	DataWindow		Index
 Bottom:	EditView		Unten:
-The message data was changed but not saved. Do you really want to quit?	MainWindow		Die Messagedaten wurden noch nicht gespeichert? Wollen Sie wirklich beenden?
-Message data	DataWindow		Messagedaten
+The message data was changed but not saved. Do you really want to quit?	MainWindow		Die geänderten Message-Daten wurden noch nicht gespeichert. Trotzdem beenden?
+Message data	DataWindow		Message-Daten
 Type	MessageView		Datentyp
 Red:	EditView		Rot:
 Error opening the message file!	App		Fehler beim Öffnen der Message-Datei!
+true	EditView		wahr
 Help	MainWindow		Hilfe
 Green:	EditView		Grün:
+false	EditView		falsch
 Index	MessageView		Index
 Left:	EditView		Links:
 Cancel	MainWindow		Abbrechen
 Width:	EditView		Breite:
-Height:	EditView		Höhe:
 Save	MainWindow		Speichern
+Height:	EditView		Höhe:
 File	MainWindow		Datei
 Open	MainWindow		Öffnen
-Number of items	MessageView		Anzahl Items
+Number of items	MessageView		Anzahl der Elemente
 Right:	EditView		Rechts:
 Value	DataWindow		Wert
 Edit	EditWindow		Bearbeiten
@@ -33,4 +35,3 @@ Save	EditWindow		Speichern
 not editable	EditView		nicht bearbeitbar
 Error reading the message from the file!	App		Fehler beim Lesen der Message-Datei!
 An editor for archived BMessages	App		Ein Editor für archivierte BMessages
-es

--- a/locales/en.catkeys
+++ b/locales/en.catkeys
@@ -1,4 +1,4 @@
-1	English	application/x-vnd.BlueSky-Kottan	2464514700
+1	English	application/x-vnd.BlueSky-Kottan	2960400911
 Name	MessageView		Name
 Blue:	EditView		Blue:
 About	MainWindow		About
@@ -12,14 +12,16 @@ Message data	DataWindow		Message data
 Type	MessageView		Type
 Red:	EditView		Red:
 Error opening the message file!	App		Error opening the message file!
+true	EditView		true
 Help	MainWindow		Help
 Green:	EditView		Green:
+false	EditView		false
 Index	MessageView		Index
 Left:	EditView		Left:
 Cancel	MainWindow		Cancel
 Width:	EditView		Width:
-Height:	EditView		Height:
 Save	MainWindow		Save
+Height:	EditView		Height:
 File	MainWindow		File
 Open	MainWindow		Open
 Number of items	MessageView		Number of items

--- a/locales/nl.catkeys
+++ b/locales/nl.catkeys
@@ -1,4 +1,4 @@
-1	English	application/x-vnd.BlueSky-Kottan	2464514700
+1	English	application/x-vnd.BlueSky-Kottan	2960400911
 Name	MessageView		Naam
 Blue:	EditView		Blue:
 About	MainWindow		Over
@@ -12,14 +12,16 @@ Message data	DataWindow		Message data
 Type	MessageView		Type
 Red:	EditView		Red:
 Error opening the message file!	App		Error opening the message file!
+true	EditView		true
 Help	MainWindow		Help
 Green:	EditView		Green:
+false	EditView		false
 Index	MessageView		Index
 Left:	EditView		Left:
 Cancel	MainWindow		Cancel
 Width:	EditView		Width:
-Height:	EditView		Height:
 Save	MainWindow		Save
+Height:	EditView		Height:
 File	MainWindow		Bestand
 Open	MainWindow		Open
 Number of items	MessageView		Number of items

--- a/locales/ru.catkeys
+++ b/locales/ru.catkeys
@@ -1,37 +1,37 @@
-1	English	application/x-vnd.BlueSky-Kottan	1453004971
+1	English	application/x-vnd.BlueSky-Kottan	2960400911
 Name	MessageView		Имя
 Blue:	EditView		Синий:
 About	MainWindow		О программе
 Top:	EditView		Верх:
-Number of Items	MessageView		Количество элементов
 data cannot be displayed	DataWindow		невозможно показать данные
 Quit	MainWindow		Выход
-No	MainWindow		Нет
 Index	DataWindow		№ п/п
 Bottom:	EditView		Низ:
+The message data was changed but not saved. Do you really want to quit?	MainWindow		The message data was changed but not saved. Do you really want to quit?
+Message data	DataWindow		Message data
 Type	MessageView		Тип данных
-Yes	MainWindow		Да
 Red:	EditView		Красный:
 Error opening the message file!	App		Ошибка при открытии файла BMessage!
+true	EditView		true
 Help	MainWindow		Помощь
 Green:	EditView		Зелёный:
+false	EditView		false
 Index	MessageView		№ п/п
-The message data was changed but not saved. Do you really want to continue?	MainWindow		Данные в BMessage были изменены, но изменения не были сохранены. Вы уверены, что хотите продолжать?
 Left:	EditView		Левая граница:
+Cancel	MainWindow		Cancel
 Width:	EditView		Ширина:
-Height:	EditView		Высота:
 Save	MainWindow		Сохранить
+Height:	EditView		Высота:
 File	MainWindow		Файл
 Open	MainWindow		Открыть
+Number of items	MessageView		Number of items
 Right:	EditView		Правая граница:
 Value	DataWindow		Значение
-Cancel	EditWindow		Отмена
 Edit	EditWindow		Редактировать
+Cancel	EditWindow		Отмена
 Close	DataWindow		Закрыть
 Alpha:	EditView		Альфа-канал:
 Save	EditWindow		Сохранить
+not editable	EditView		not editable
 Error reading the message from the file!	App		Ошибка при чтении BMessage из файла!
-Message Data	DataWindow		Данные BMessage
 An editor for archived BMessages	App		Редактор сохранённых файлов BMessage
-essage
-essage

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -120,9 +120,11 @@ App::MessageReceived(BMessage *msg)
 										fSelectedName,
 										fSelectedType,
 								        fSelectedItemCount);
-													 
-			fDataWindow->CenterOnScreen();
-			fDataWindow->Show();		
+
+			fDataWindow->CenterIn(fMainWindow->Frame());
+			fDataWindow->MoveBy(0, 128);
+			fDataWindow->MoveOnScreen(B_MOVE_IF_PARTIALLY_OFFSCREEN);
+			fDataWindow->Show();
 			
 			break;
 		}
@@ -149,7 +151,7 @@ App::MessageReceived(BMessage *msg)
 													fSelectedType,
 													fSelectedName,
 													field_index);
-			edit_window->CenterOnScreen();
+			edit_window->CenterIn(fDataWindow->Frame());
 			edit_window->Show();
 			
 			break;

--- a/src/editview.cpp
+++ b/src/editview.cpp
@@ -206,8 +206,8 @@ EditView::setup_controls()
 			fDataMessage->FindBool(fDataLabel, fDataIndex, &data_bool);	
 			int32 default_item = static_cast<int32>(data_bool);
 		
-			fPopUpMenu->AddItem(new BMenuItem("false", new BMessage(EV_DATA_CHANGED)));
-			fPopUpMenu->AddItem(new BMenuItem("true", new BMessage(EV_DATA_CHANGED)));
+			fPopUpMenu->AddItem(new BMenuItem(B_TRANSLATE("false"), new BMessage(EV_DATA_CHANGED)));
+			fPopUpMenu->AddItem(new BMenuItem(B_TRANSLATE("true"), new BMessage(EV_DATA_CHANGED)));
 			fPopUpMenu->ItemAt(default_item)->SetMarked(true);
 			
 			BMenuField *bool_select = new BMenuField("",fPopUpMenu);


### PR DESCRIPTION
I suppose at one time, you'd want to save the main window position instead of opening in center of screen. The data window can then still open relative to the main window, or you save its position individually, too. The edit window should always open in the center of the data window, I suppose... If you stick with the separate data window... :)

BTW, you could add Kottan to https://i18n.kacperkasper.pl/ for more translations (if you don't expect the GUI strings to change too much in the near future).